### PR TITLE
Fix object pose mutation on TAMPEnvironment and expose version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+## [0.0.2] - 2026-04-01
+
+### Added
+- Expose `__version__` in `__init__.py` via `importlib.metadata`
+
+### Fixed
+- Disable CPU pose update to avoid mutating object pose in `TAMPEnvironment`
+
+## [0.0.1] - 2026-03-22
+
+### Added
+- Initial release of cuTAMP from NVLabs — GPU-parallelized TAMP solver with core algorithm, cost functions, rollout, samplers, task planning search, and environment definitions (book shelf, stick button, tetris)
+- Robot support for Franka Panda, FR3, and UR5e with Robotiq 2F-85/140 grippers
+- TiPToP integration: extended algorithm and motion solver, added Franka+Robotiq robot config, OBB collision utilities, new environment assets
+- Return failure reason from planner for better diagnostics
+- Log git status in experiment logger

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # cuTAMP: Differentiable GPU-Parallelized Task and Motion Planning
 
+> **Note:** This is a fork of the original [cuTAMP](https://github.com/NVlabs/cuTAMP) with modifications to support [TiPToP](https://tiptop-robot.github.io). See [CHANGELOG.md](CHANGELOG.md) for version history.
+
 ### [🌐 Project Website](https://cutamp.github.io) | [📝 Paper](https://arxiv.org/abs/2411.11833)
 
 > **Differentiable GPU-Parallelized Task and Motion Planning**  

--- a/cutamp/__init__.py
+++ b/cutamp/__init__.py
@@ -6,3 +6,10 @@
 # disclosure or distribution of this material and related documentation
 # without an express license agreement from NVIDIA CORPORATION or
 # its affiliates is strictly prohibited.
+
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("cutamp")
+except PackageNotFoundError:
+    __version__ = "unknown"

--- a/cutamp/motion_solver.py
+++ b/cutamp/motion_solver.py
@@ -71,7 +71,7 @@ def solve_curobo(
     for obj, obj_pose in obj_to_current_pose.items():
         motion_gen.world_coll_checker.enable_obstacle(enable=True, name=obj)
         obj_pose = obj_to_current_pose[obj]
-        motion_gen.world_collision.update_obstacle_pose(obj, Pose.from_matrix(obj_pose), update_cpu_reference=True)
+        motion_gen.world_collision.update_obstacle_pose(obj, Pose.from_matrix(obj_pose))
 
     visualizer.set_time_seconds(timeline, ts)
     visualizer.set_joint_positions(best_particle["q0"])
@@ -198,7 +198,7 @@ def solve_curobo(
                 pts = spheres[:, :3].cpu().numpy()
                 n_radius = spheres[:, 3].cpu().numpy()
 
-                obj_pose = Pose.from_list(self.pose, self.tensor_args)
+                obj_pose = Pose.from_matrix(obj_to_current_pose[obj])
                 pre_transform_pose = kwargs["pre_transform_pose"]
                 if pre_transform_pose is not None:
                     obj_pose = pre_transform_pose.multiply(obj_pose)  # convert object pose to another frame
@@ -364,9 +364,7 @@ def solve_curobo(
                 motion_gen.detach_object_from_robot("attached_object")
                 motion_gen.world_coll_checker.enable_obstacle(enable=True, name=obj)
                 obj_pose = obj_to_current_pose[obj]
-                motion_gen.world_collision.update_obstacle_pose(
-                    obj, Pose.from_matrix(obj_pose), update_cpu_reference=True
-                )
+                motion_gen.world_collision.update_obstacle_pose(obj, Pose.from_matrix(obj_pose))
 
             # Open the gripper for visualization purposes
             if config.robot == "ur5" or config.robot == "fr3_robotiq":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@
 
 [project]
 name = "cuTAMP"
-version = "0.0.1"
+version = "0.0.2"
 description = "cuTAMP"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
We were updating the CPU pose reference for obstacles, which meant when we serialized the TAMPEnvironment after planning the objects would not be at their initial poses but their poses at the end.

Also fixes the monkey patch to use the current object pose that we track within motion solver instead of from the object CPU pose reference.