### PR TITLE
Add max_motion_refine_attempts and retry next skeleton on motion failure

### DIFF
--- a/cutamp/algorithm.py
+++ b/cutamp/algorithm.py
@@ -625,7 +625,7 @@ def run_cutamp(
                 num_satisfying = ranked_particles["q0"].shape[0]
                 max_attempts = min(config.max_motion_refine_attempts or num_satisfying, num_satisfying)
                 for curr_idx in range(max_attempts):
-                    _log.info(f"Trying cuRobo planning with satisfying particle {curr_idx + 1}/{max_attempts}")
+                    _log.info(f"Trying cuRobo planning with satisfying particle {curr_idx + 1}/{max_attempts} ({num_satisfying} total satisfying)")
                     curr_particle = {k: v[curr_idx] for k, v in ranked_particles.items()}
                     try:
                         curobo_plan = solve_curobo(

--- a/cutamp/algorithm.py
+++ b/cutamp/algorithm.py
@@ -661,7 +661,6 @@ def run_cutamp(
                 # start of the next skeleton's resampling loop.
                 _log.info(f"Motion refinement failed for skeleton {[op.name for op in plan_skeleton]}, trying next")
                 should_break = False
-                failure_reason = None
             elif config.break_on_satisfying:
                 should_break = True
 
@@ -677,6 +676,10 @@ def run_cutamp(
 
     opt_elapsed = timer.stop("start_optimization")
     _log.debug(f"Optimization loop took roughly {opt_elapsed:.2f}s")
+    if found_solution and config.curobo_plan and curobo_plan is None:
+        found_solution = False
+        if failure_reason is None:
+            failure_reason = "Motion planning failed for all skeletons with satisfying particles"
     if not found_solution:
         if len(plan_queue) == 0:
             if num_skipped_plans > 0:

--- a/cutamp/algorithm.py
+++ b/cutamp/algorithm.py
@@ -640,6 +640,7 @@ def run_cutamp(
                             motion_gen=motion_gen,
                         )
                         _log.info("Successful plan found!")
+                        failure_reason = None
                         break
                     except MotionPlanningError as e:
                         _log.warning(f"Failed to motion plan: {e}")
@@ -654,9 +655,13 @@ def run_cutamp(
             overall_metrics["final_plan_skeleton"] = [str(op) for op in plan_skeleton]
             _log.debug(f"Total num satisfying {metrics['num_satisfying_final']}")
             if config.curobo_plan and curobo_plan is None:
-                # Motion refinement failed, try next skeleton
+                # Motion refinement failed, try next skeleton. Intentionally overrides should_break
+                # set by break_on_satisfying during resampling — we don't want to stop on a skeleton
+                # where motion planning failed. The max_loop_dur timeout will still be checked at the
+                # start of the next skeleton's resampling loop.
                 _log.info(f"Motion refinement failed for skeleton {[op.name for op in plan_skeleton]}, trying next")
                 should_break = False
+                failure_reason = None
             elif config.break_on_satisfying:
                 should_break = True
 

--- a/cutamp/algorithm.py
+++ b/cutamp/algorithm.py
@@ -647,8 +647,9 @@ def run_cutamp(
                 else:
                     # All attempted particles failed motion planning
                     if curobo_plan is None:
+                        max_reached = " (max attempts reached)" if max_attempts < num_satisfying else ""
                         failure_reason = (
-                            f"Motion planning failed for {max_attempts}/{num_satisfying} satisfying particle(s)"
+                            f"Motion planning failed for {max_attempts}/{num_satisfying} satisfying particle(s){max_reached}"
                         )
 
             overall_metrics["num_satisfying_final"] = metrics["num_satisfying_final"]

--- a/cutamp/algorithm.py
+++ b/cutamp/algorithm.py
@@ -623,8 +623,9 @@ def run_cutamp(
                     _log.info(f"Updated motion gen with world cfg")
 
                 num_satisfying = ranked_particles["q0"].shape[0]
-                for curr_idx in range(num_satisfying):
-                    _log.info(f"Trying cuRobo planning with satisfying particle {curr_idx + 1}/{num_satisfying}")
+                max_attempts = min(config.max_motion_refine_attempts or num_satisfying, num_satisfying)
+                for curr_idx in range(max_attempts):
+                    _log.info(f"Trying cuRobo planning with satisfying particle {curr_idx + 1}/{max_attempts}")
                     curr_particle = {k: v[curr_idx] for k, v in ranked_particles.items()}
                     try:
                         curobo_plan = solve_curobo(
@@ -643,16 +644,20 @@ def run_cutamp(
                     except MotionPlanningError as e:
                         _log.warning(f"Failed to motion plan: {e}")
                 else:
-                    # All satisfying particles failed motion planning
+                    # All attempted particles failed motion planning
                     if curobo_plan is None:
                         failure_reason = (
-                            f"Motion planning failed for all {num_satisfying} satisfying particle(s)"
+                            f"Motion planning failed for {max_attempts}/{num_satisfying} satisfying particle(s)"
                         )
 
             overall_metrics["num_satisfying_final"] = metrics["num_satisfying_final"]
             overall_metrics["final_plan_skeleton"] = [str(op) for op in plan_skeleton]
             _log.debug(f"Total num satisfying {metrics['num_satisfying_final']}")
-            if config.break_on_satisfying:
+            if config.curobo_plan and curobo_plan is None:
+                # Motion refinement failed, try next skeleton
+                _log.info(f"Motion refinement failed for skeleton {[op.name for op in plan_skeleton]}, trying next")
+                should_break = False
+            elif config.break_on_satisfying:
                 should_break = True
 
         if should_break:

--- a/cutamp/config.py
+++ b/cutamp/config.py
@@ -86,6 +86,8 @@ class TAMPConfiguration:
     enable_traj: bool = False
     # Motion plan with cuRobo after optimization
     curobo_plan: bool = False
+    # Max satisfying particles to try motion refinement on per skeleton (None = try all)
+    max_motion_refine_attempts: Optional[int] = None
     # For slowing down cuRobo motion plans (0.5 is safe on the real robot)
     time_dilation_factor: Optional[float] = None
     # Whether to warmup IK solver
@@ -150,6 +152,10 @@ def validate_tamp_config(config: TAMPConfiguration):
         raise ValueError(f"world_activation_distance must be non-negative, not {config.world_activation_distance}")
     if config.movable_activation_distance < 0:
         raise ValueError(f"movable_activation_distance must be non-negative, not {config.movable_activation_distance}")
+
+    # Motion refinement
+    if config.max_motion_refine_attempts is not None and config.max_motion_refine_attempts <= 0:
+        raise ValueError(f"max_motion_refine_attempts must be positive or None, not {config.max_motion_refine_attempts}")
 
     # Placement region checks
     if config.placement_check != "obb" and config.placement_shrink_dist is not None:

--- a/cutamp/scripts/run_cutamp.py
+++ b/cutamp/scripts/run_cutamp.py
@@ -151,6 +151,12 @@ def entrypoint():
         action="store_true",
         help="Whether to plan for full motions after using cuTAMP. Not supported in stick_button domain yet.",
     )
+    parser.add_argument(
+        "--max_motion_refine_attempts",
+        type=int,
+        default=None,
+        help="Max satisfying particles to try motion refinement on per skeleton. None = try all.",
+    )
 
     # Visualization and logging
     parser.add_argument(
@@ -209,6 +215,7 @@ def entrypoint():
         num_initial_plans=args.num_initial_plans,
         cache_subgraphs=args.cache_subgraphs,
         curobo_plan=args.motion_plan,
+        max_motion_refine_attempts=args.max_motion_refine_attempts,
         enable_visualizer=not args.disable_visualizer,
         opt_viz_interval=args.viz_interval,
         viz_robot_mesh=not args.disable_robot_mesh,


### PR DESCRIPTION
## Summary
- Adds `max_motion_refine_attempts` to `TAMPConfiguration` to cap the number of satisfying particles tried during cuRobo motion refinement per skeleton (default `None` = try all)
- When `curobo_plan=True` and motion refinement fails for all attempted particles, the algorithm now falls through to the next plan skeleton instead of breaking
- `break_on_satisfying` behavior preserved when `curobo_plan` is off (for benchmarking)
- Exposes `--max_motion_refine_attempts` as a CLI arg in `run_cutamp.py`

Closes #4

## Test plan
Tested on `book_shelf` env (`grasp_dof=6, --motion_plan, --disable_visualizer`):
- `max_motion_refine_attempts=4`: verified cap respected (logs show "X/4"), particle 3/4 succeeded after 1 and 2 failed with IK_FAIL
- `max_motion_refine_attempts=1`: verified skeleton fallthrough — Opt 1 failed motion refinement, logged "Motion refinement failed for skeleton ..., trying next", then moved to Opt 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)