### PR TITLE
Guard against bfs running forever

### DIFF
--- a/cutamp/task_planning/search.py
+++ b/cutamp/task_planning/search.py
@@ -255,6 +255,27 @@ def breadth_first_search(
         if not isinstance(elem, Atom):
             raise ValueError(f"Goal state must contain only atoms, got {elem.__class__.__name__} {elem}")
 
+    # Reject goal atoms whose literals can never appear in any reachable state.
+    # Operator sampling fabricates fresh symbols only for the internal types below;
+    # any other type (movable, surface, ...) must already be in the initial state,
+    # otherwise BFS expands fresh conf/pose/traj/grasp samples forever without ever satisfying the goal.
+    fabricable_types = {"conf", "pose", "traj", "grasp"}
+    initial_literals_by_type: dict[str, set[str]] = defaultdict(set)
+    for atom in initial_state:
+        for param, value in zip(atom.fluent.parameters, atom.values):
+            initial_literals_by_type[param.type].add(value)
+    for atom in goal_state:
+        for param, value in zip(atom.fluent.parameters, atom.values):
+            if param.type in fabricable_types:
+                continue
+            if value not in initial_literals_by_type.get(param.type, set()):
+                known = sorted(initial_literals_by_type.get(param.type, set()))
+                raise ValueError(
+                    f"Goal atom {atom} references unknown {param.type} literal "
+                    f"'{value}' that does not appear in the initial state. "
+                    f"Known {param.type} literals: {known}"
+                )
+
     # Pre-compute precondition fluent sets for each operator (optimization)
     operator_precond_fluents = [frozenset(pre.name for pre in op.preconditions) for op in operators]
 

--- a/cutamp/task_planning/search.py
+++ b/cutamp/task_planning/search.py
@@ -138,17 +138,23 @@ def get_valid_ground_operators(
 
         # This is hacky and could break things due to naming, but ok for now
         def _sample_param_type(param_type: str) -> str:
-            if param_type in param_type_to_literals:
-                if param_type not in _FABRICABLE_TYPE_PREFIXES:
-                    raise NotImplementedError
-                # Existing literals follow the convention `<prefix><N>` (e.g. q0, q1, pose3).
-                # Strip the prefix to recover N for each existing literal, then mint a fresh
-                # symbol one past the current max — e.g. {q0, q1, q2} -> "q3".
-                prefix = _FABRICABLE_TYPE_PREFIXES[param_type]
-                existing_nums = {int(lit[len(prefix):]) for lit in param_type_to_literals[param_type]}
-                return f"{prefix}{max(existing_nums) + 1}"
-            else:
-                return f"{param_type}1"
+            # Only fabricable types can be minted by the planner. Non-fabricable types
+            # (movable, surface, ...) must come from the initial state — the goal-state
+            # validator at the top of breadth_first_search relies on this invariant.
+            if param_type not in _FABRICABLE_TYPE_PREFIXES:
+                raise NotImplementedError(
+                    f"Cannot fabricate fresh symbols for non-fabricable type '{param_type}'; "
+                    f"literals of this type must come from the initial state."
+                )
+            prefix = _FABRICABLE_TYPE_PREFIXES[param_type]
+            if param_type not in param_type_to_literals:
+                # First time we see this type — mint the seed symbol (e.g. "q1").
+                return f"{prefix}1"
+            # Existing literals follow the convention `<prefix><N>` (e.g. q0, q1, pose3).
+            # Strip the prefix to recover N for each existing literal, then mint a fresh
+            # symbol one past the current max — e.g. {q0, q1, q2} -> "q3".
+            existing_nums = {int(lit[len(prefix):]) for lit in param_type_to_literals[param_type]}
+            return f"{prefix}{max(existing_nums) + 1}"
 
         def sample_param_type(param_type: str) -> str:
             new_sample = _sample_param_type(param_type)

--- a/cutamp/task_planning/search.py
+++ b/cutamp/task_planning/search.py
@@ -17,6 +17,21 @@ from cutamp.task_planning import Atom, GroundOperator, Operator, State
 
 _log = logging.getLogger(__name__)
 
+# Param types whose literals are fabricated by the planner during operator grounding
+# (see `_sample_param_type` in `get_valid_ground_operators`). The mapping value is the
+# prefix used when minting fresh symbols (e.g. q0, q1, ... for `conf`). Goal atoms of
+# these types do not need to be present in the initial state; goal atoms of any other
+# type must be, otherwise BFS would expand the frontier forever without ever satisfying
+# the goal. Both the sampler and the goal-state validator read from this single source
+# so they cannot drift out of sync.
+_FABRICABLE_TYPE_PREFIXES: dict[str, str] = {
+    "conf": "q",
+    "pose": "pose",
+    "traj": "traj",
+    "grasp": "grasp",
+}
+FABRICABLE_TYPES: frozenset[str] = frozenset(_FABRICABLE_TYPE_PREFIXES)
+
 
 @dataclass
 class _Node:
@@ -124,25 +139,14 @@ def get_valid_ground_operators(
         # This is hacky and could break things due to naming, but ok for now
         def _sample_param_type(param_type: str) -> str:
             if param_type in param_type_to_literals:
-                if param_type == "conf":
-                    # remove the 'q' prefix
-                    conf_nums = {int(lit[1:]) for lit in param_type_to_literals[param_type]}
-                    conf_max = max(conf_nums)
-                    return f"q{conf_max + 1}"
-                elif param_type == "pose":
-                    pose_nums = {int(lit[4:]) for lit in param_type_to_literals[param_type]}
-                    pose_max = max(pose_nums)
-                    return f"pose{pose_max + 1}"
-                elif param_type == "traj":
-                    traj_nums = {int(lit[4:]) for lit in param_type_to_literals[param_type]}
-                    traj_max = max(traj_nums)
-                    return f"traj{traj_max + 1}"
-                elif param_type == "grasp":
-                    grasp_nums = {int(lit[5:]) for lit in param_type_to_literals[param_type]}
-                    grasp_max = max(grasp_nums)
-                    return f"grasp{grasp_max + 1}"
-                else:
+                if param_type not in _FABRICABLE_TYPE_PREFIXES:
                     raise NotImplementedError
+                # Existing literals follow the convention `<prefix><N>` (e.g. q0, q1, pose3).
+                # Strip the prefix to recover N for each existing literal, then mint a fresh
+                # symbol one past the current max — e.g. {q0, q1, q2} -> "q3".
+                prefix = _FABRICABLE_TYPE_PREFIXES[param_type]
+                existing_nums = {int(lit[len(prefix):]) for lit in param_type_to_literals[param_type]}
+                return f"{prefix}{max(existing_nums) + 1}"
             else:
                 return f"{param_type}1"
 
@@ -256,17 +260,16 @@ def breadth_first_search(
             raise ValueError(f"Goal state must contain only atoms, got {elem.__class__.__name__} {elem}")
 
     # Reject goal atoms whose literals can never appear in any reachable state.
-    # Operator sampling fabricates fresh symbols only for the internal types below;
-    # any other type (movable, surface, ...) must already be in the initial state,
-    # otherwise BFS expands fresh conf/pose/traj/grasp samples forever without ever satisfying the goal.
-    fabricable_types = {"conf", "pose", "traj", "grasp"}
+    # Operator sampling fabricates fresh symbols only for FABRICABLE_TYPES; literals
+    # of any other type (movable, surface, ...) must already be in the initial state,
+    # otherwise BFS expands fresh samples forever without satisfying the goal.
     initial_literals_by_type: dict[str, set[str]] = defaultdict(set)
     for atom in initial_state:
         for param, value in zip(atom.fluent.parameters, atom.values):
             initial_literals_by_type[param.type].add(value)
     for atom in goal_state:
         for param, value in zip(atom.fluent.parameters, atom.values):
-            if param.type in fabricable_types:
+            if param.type in FABRICABLE_TYPES:
                 continue
             if value not in initial_literals_by_type.get(param.type, set()):
                 known = sorted(initial_literals_by_type.get(param.type, set()))

--- a/tests/test_task_planning.py
+++ b/tests/test_task_planning.py
@@ -1,0 +1,47 @@
+"""Tests for cutamp.task_planning.search.
+
+Run with: pytest tests/test_task_planning.py -v
+"""
+
+import pytest
+
+from cutamp.task_planning import Fluent, Parameter
+from cutamp.task_planning.search import breadth_first_search
+
+On = Fluent("On", [Parameter("?o", "movable"), Parameter("?s", "surface")])
+HandEmpty = Fluent("HandEmpty", [])
+IsSurface = Fluent("IsSurface", [Parameter("?s", "surface")])
+IsMovable = Fluent("IsMovable", [Parameter("?o", "movable")])
+
+
+def _initial_state():
+    return frozenset({HandEmpty.ground(), IsSurface.ground("bowl"), IsMovable.ground("book")})
+
+
+def test_unknown_movable_in_goal_raises():
+    """Goal referencing a movable not in the initial state should fail fast, not hang BFS."""
+    initial = _initial_state()
+    goal = frozenset({On.ground("spoon", "bowl"), HandEmpty.ground()})
+
+    with pytest.raises(ValueError, match=r"unknown movable literal 'spoon'"):
+        list(breadth_first_search(initial, goal, []))
+
+
+def test_unknown_surface_in_goal_raises():
+    """Goal referencing a surface not in the initial state should fail fast, not hang BFS."""
+    initial = _initial_state()
+    goal = frozenset({On.ground("book", "shelf"), HandEmpty.ground()})
+
+    with pytest.raises(ValueError, match=r"unknown surface literal 'shelf'"):
+        list(breadth_first_search(initial, goal, []))
+
+
+def test_known_goal_literals_pass_validation():
+    """Goal whose literals all appear in the initial state should not raise during validation."""
+    initial = _initial_state()
+    goal = frozenset({On.ground("book", "bowl"), HandEmpty.ground()})
+
+    # No operators provided, so BFS finishes without yielding plans — the point is that the
+    # goal-literal validation does not raise on a well-formed goal.
+    plans = list(breadth_first_search(initial, goal, []))
+    assert plans == []

--- a/tests/test_task_planning.py
+++ b/tests/test_task_planning.py
@@ -3,7 +3,10 @@
 Run with: pytest tests/test_task_planning.py -v
 """
 
+import os
+
 import pytest
+import torch
 
 from cutamp.task_planning import Fluent, Parameter
 from cutamp.task_planning.search import breadth_first_search
@@ -12,6 +15,8 @@ On = Fluent("On", [Parameter("?o", "movable"), Parameter("?s", "surface")])
 HandEmpty = Fluent("HandEmpty", [])
 IsSurface = Fluent("IsSurface", [Parameter("?s", "surface")])
 IsMovable = Fluent("IsMovable", [Parameter("?o", "movable")])
+
+gpu = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires GPU")
 
 
 def _initial_state():
@@ -45,3 +50,41 @@ def test_known_goal_literals_pass_validation():
     # goal-literal validation does not raise on a well-formed goal.
     plans = list(breadth_first_search(initial, goal, []))
     assert plans == []
+
+
+@gpu
+def test_unknown_goal_literal_propagates_through_run_cutamp():
+    """Regression for the perception-hallucination hang: a goal that names an object not in the
+    scene must surface as a `ValueError` from `run_cutamp` (not hang BFS forever). Mirrors the
+    failure mode reported from tiptop where a hallucinated `On(spoon, bowl)` goal caused cuTAMP
+    to spin in BFS until the process was killed."""
+    from cutamp.algorithm import run_cutamp
+    from cutamp.config import TAMPConfiguration
+    from cutamp.constraint_checker import ConstraintChecker
+    from cutamp.cost_reduction import CostReducer
+    from cutamp.envs.utils import get_env_dir, load_env
+    from cutamp.scripts.utils import default_constraint_to_mult, default_constraint_to_tol
+    from cutamp.tamp_domain import HandEmpty as DomainHandEmpty
+    from cutamp.tamp_domain import On as DomainOn
+
+    env = load_env(os.path.join(get_env_dir(), "blocks_5.yml"))
+
+    # Override the goal with a hallucinated movable ("spoon") that does not exist in blocks_5.
+    # The "goal" surface does exist in the env (it's the green target region); the bug is in the
+    # movable arg.
+    env.goal_state = frozenset({DomainOn.ground("spoon", "goal"), DomainHandEmpty.ground()})
+
+    config = TAMPConfiguration(
+        num_particles=64,
+        robot="fr3_robotiq",
+        num_opt_steps=10,
+        max_loop_dur=20.0,
+        enable_visualizer=False,
+        rr_spawn=False,
+        enable_experiment_logging=False,
+    )
+    cost_reducer = CostReducer(default_constraint_to_mult.copy())
+    constraint_checker = ConstraintChecker(default_constraint_to_tol.copy())
+
+    with pytest.raises(ValueError, match=r"unknown movable literal 'spoon'"):
+        run_cutamp(env, config, cost_reducer, constraint_checker)


### PR DESCRIPTION
We encountered an error where cutamp BFS can run forever if the goal contains an object that doesn't exist in the initial state. This PR introduces a quick fix to guard agains tthis and just raise a ValueError.