### PR TITLE
Support pick and place next to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.0.6] - 2026-06-08
+
+All changes in this release are from #22 (place next to support).
+
+### Added
+- `Near(obj, reference)` fluent and `PlaceNear` operator for placing an object next to a reference object, with a `NearPlacement` constraint and a one-sided lateral-distance cost (#22)
+- `near_placement` config flag (default `False`) gating the `PlaceNear` operator; a `Near` goal with the flag off raises `ValueError` instead of searching forever (#22)
+- `place_near` demo environment plus `--near_placement` CLI flag on `cutamp-demo` (#22)
+- `tests/test_near_placement.py` covering `Near`/`PlaceNear` planning gating and end-to-end `NearPlacement` satisfaction (#22)
+
 ## [0.0.5] - 2026-05-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 ## [0.0.6] - 2026-06-08
 
-All changes in this release are from #22 (place next to support).
-
 ### Added
 - `Near(obj, reference)` fluent and `PlaceNear` operator for placing an object next to a reference object, with a `NearPlacement` constraint and a one-sided lateral-distance cost (#22)
 - `near_placement` config flag (default `False`) gating the `PlaceNear` operator; a `Near` goal with the flag off raises `ValueError` instead of searching forever (#22)
 - `place_near` demo environment plus `--near_placement` CLI flag on `cutamp-demo` (#22)
 - `tests/test_near_placement.py` covering `Near`/`PlaceNear` planning gating and end-to-end `NearPlacement` satisfaction (#22)
+
+### Fixed
+- Retract trajectory now returns `optimized_plan`/`optimized_dt` from the retract motion-gen result instead of the preceding placement result (#16, #21)
 
 ## [0.0.5] - 2026-05-19
 

--- a/cutamp/algorithm.py
+++ b/cutamp/algorithm.py
@@ -32,7 +32,7 @@ from cutamp.optimize_plan import ParticleOptimizer
 from cutamp.particle_initialization import ParticleInitializer
 from cutamp.robots import get_q_home, load_robot_container
 from cutamp.rollout import RolloutFunction
-from cutamp.tamp_domain import all_tamp_operators
+from cutamp.tamp_domain import Near, PlaceNear, all_tamp_operators
 from cutamp.tamp_world import TAMPWorld, check_tamp_world_not_in_collision
 from cutamp.task_planning import PlanSkeleton, task_plan_generator
 from cutamp.utils.common import get_world_cfg
@@ -407,14 +407,19 @@ def run_cutamp(
     exp_logger, visualizer, timer, world = setup_cutamp(env, config, q_init, experiment_id, ik_solver, experiment_dir)
     particle_initializer = ParticleInitializer(world, config, grasps)
 
-    # Task plan generator
+    if any(atom.name == Near.name for atom in world.goal_state) and not config.near_placement:
+        raise ValueError(
+            "Goal contains a Near atom but config.near_placement is False."
+        )
+    operators = all_tamp_operators if config.near_placement else [op for op in all_tamp_operators if op is not PlaceNear]
+
     _log.info(f"Initial State: {world.initial_state}")
     _log.info(f"Goal State: {world.goal_state}")
     with timer.time("get_plan_generator", log_callback=_log.info):
         plan_gen = task_plan_generator(
             world.initial_state,
             world.goal_state,
-            operators=all_tamp_operators,
+            operators=operators,
             explored_state_check=config.explored_state_check,
         )
 

--- a/cutamp/algorithm.py
+++ b/cutamp/algorithm.py
@@ -10,6 +10,7 @@
 """Core cuTAMP algorithm implementation."""
 
 import logging
+import warnings
 from datetime import datetime
 from pathlib import Path
 from typing import List, Union, Optional, Tuple
@@ -411,6 +412,8 @@ def run_cutamp(
         raise ValueError(
             "Goal contains a Near atom but config.near_placement is False."
         )
+    if config.near_placement:
+        warnings.warn("config.near_placement is enabled — PlaceNear is experimental. Tune for your use case.")
     operators = all_tamp_operators if config.near_placement else [op for op in all_tamp_operators if op is not PlaceNear]
 
     _log.info(f"Initial State: {world.initial_state}")

--- a/cutamp/config.py
+++ b/cutamp/config.py
@@ -48,6 +48,8 @@ class TAMPConfiguration:
     stick_button_experiment: bool = False
 
     ## Experimental Stuff
+    # Whether to enable the PlaceNear operator. You should tune the NearPlacement cost weight and tolerance.
+    near_placement: bool = False
     # Whether to check placements using AABB or OBB formulation
     placement_check: Literal["aabb", "obb"] = "aabb"
     # Distance to shrink the placement region check on all sides, only supported for OBB right now

--- a/cutamp/cost_function.py
+++ b/cutamp/cost_function.py
@@ -465,8 +465,8 @@ class CostFunction:
             obj_name, placement, ref_name = con.params
             pose_ts = rollout["action_to_pose_ts"][placement]
             # Read both poses at the placement timestep so the reference's current location is used.
-            obj_xy = rollout["obj_to_pose"][obj_name][:, pose_ts][:, :2, 3]  # (b, 2)
-            ref_xy = rollout["obj_to_pose"][ref_name][:, pose_ts][:, :2, 3]  # (b, 2)
+            obj_xy = rollout["obj_to_pose"][obj_name][:, pose_ts, :2, 3]  # (b, 2)
+            ref_xy = rollout["obj_to_pose"][ref_name][:, pose_ts, :2, 3]  # (b, 2)
             dist_xy = torch.linalg.norm(obj_xy - ref_xy, dim=-1)  # (b,)
             # Shape (b, 1) to match the 2-D convention used by other constraints
             # (e.g. StablePlacement). heuristic_fn in algorithm.py only handles 2-D values correctly.

--- a/cutamp/cost_function.py
+++ b/cutamp/cost_function.py
@@ -145,16 +145,13 @@ class CostFunction:
 
         # Pre-compute per-constraint NearPlacement thresholds: center-to-center xy distance plus a 3cm gap.
         self.near_thresholds = []  # per-constraint scalar threshold (matches order of near_placement_constraints)
-        device = self.world.device
         for con in self.near_placement_constraints:
             obj_name, _, ref_name = con.params
             ref_aabb = self.world.get_aabb(ref_name)
-            ref_half = ((ref_aabb[1, :2] - ref_aabb[0, :2]).max() / 2).item()
+            ref_half = (ref_aabb[1, :2] - ref_aabb[0, :2]).max() / 2
             obj_aabb = self.world.get_aabb(obj_name)
-            obj_half = ((obj_aabb[1, :2] - obj_aabb[0, :2]).max() / 2).item()
-            self.near_thresholds.append(
-                torch.tensor(ref_half + obj_half + 0.03, dtype=torch.float32, device=device)
-            )
+            obj_half = (obj_aabb[1, :2] - obj_aabb[0, :2]).max() / 2
+            self.near_thresholds.append(ref_half + obj_half + 0.03)
 
         # Store the button AABBs for ValidPush
         self.button_to_action = {}
@@ -473,7 +470,7 @@ class CostFunction:
             dist_xy = torch.linalg.norm(obj_xy - ref_xy, dim=-1)  # (b,)
             # Shape (b, 1) to match the 2-D convention used by other constraints
             # (e.g. StablePlacement). heuristic_fn in algorithm.py only handles 2-D values correctly.
-            near_vals[f"{obj_name}_near_{ref_name}"] = torch.relu(dist_xy - threshold).unsqueeze(-1)
+            near_vals[f"{obj_name}_near_{ref_name}_{placement}"] = torch.relu(dist_xy - threshold).unsqueeze(-1)
 
         return {
             "type": "constraint",

--- a/cutamp/cost_function.py
+++ b/cutamp/cost_function.py
@@ -143,17 +143,13 @@ class CostFunction:
             target_z = surface_z + world.collision_activation_distance + 2e-3  # add some buffer
             self.surface_to_target_z[surface] = target_z
 
-        # Pre-compute reference xy positions and per-constraint distance thresholds for NearPlacement.
-        # Threshold = ref_half_extent + obj_half_extent + 3cm gap, derived from initial-pose AABBs.
-        self.near_ref_xy = {}  # reference name -> (2,) tensor
+        # Pre-compute per-constraint NearPlacement thresholds: center-to-center xy distance plus a 3cm gap.
         self.near_thresholds = []  # per-constraint scalar threshold (matches order of near_placement_constraints)
         device = self.world.device
         for con in self.near_placement_constraints:
             obj_name, _, ref_name = con.params
-            if ref_name not in self.near_ref_xy:
-                ref_aabb = self.world.get_aabb(ref_name)
-                self.near_ref_xy[ref_name] = (ref_aabb[0, :2] + ref_aabb[1, :2]) / 2
-            ref_half = ((self.world.get_aabb(ref_name)[1, :2] - self.world.get_aabb(ref_name)[0, :2]).max() / 2).item()
+            ref_aabb = self.world.get_aabb(ref_name)
+            ref_half = ((ref_aabb[1, :2] - ref_aabb[0, :2]).max() / 2).item()
             obj_aabb = self.world.get_aabb(obj_name)
             obj_half = ((obj_aabb[1, :2] - obj_aabb[0, :2]).max() / 2).item()
             self.near_thresholds.append(
@@ -471,10 +467,10 @@ class CostFunction:
         for con, threshold in zip(self.near_placement_constraints, self.near_thresholds):
             obj_name, placement, ref_name = con.params
             pose_ts = rollout["action_to_pose_ts"][placement]
-            obj_pose = rollout["obj_to_pose"][obj_name][:, pose_ts]  # (b, 4, 4)
-            obj_xy = obj_pose[:, :2, 3]  # (b, 2)
-            ref_xy = self.near_ref_xy[ref_name]
-            dist_xy = torch.linalg.norm(obj_xy - ref_xy[None], dim=-1)  # (b,)
+            # Read both poses at the placement timestep so the reference's current location is used.
+            obj_xy = rollout["obj_to_pose"][obj_name][:, pose_ts][:, :2, 3]  # (b, 2)
+            ref_xy = rollout["obj_to_pose"][ref_name][:, pose_ts][:, :2, 3]  # (b, 2)
+            dist_xy = torch.linalg.norm(obj_xy - ref_xy, dim=-1)  # (b,)
             # Shape (b, 1) to match the 2-D convention used by other constraints
             # (e.g. StablePlacement). heuristic_fn in algorithm.py only handles 2-D values correctly.
             near_vals[f"{obj_name}_near_{ref_name}"] = torch.relu(dist_xy - threshold).unsqueeze(-1)

--- a/cutamp/cost_function.py
+++ b/cutamp/cost_function.py
@@ -33,6 +33,7 @@ from cutamp.task_planning.constraints import (
     CollisionFreePlacement,
     KinematicConstraint,
     Motion,
+    NearPlacement,
     StablePlacement,
     ValidPush,
     ValidPushStick,
@@ -64,6 +65,7 @@ class CostFunction:
         self.kinematic_constraints = []
         self.motion_constraints = []
         self.stable_placement_constraints = []
+        self.near_placement_constraints = []
         self.valid_push_constraints = []
         self.valid_push_stick_constraints = []
         self.traj_length_costs = []
@@ -76,6 +78,7 @@ class CostFunction:
             CollisionFreeGrasp.type: self.cfree_constraints,
             CollisionFreePlacement.type: self.cfree_constraints,
             StablePlacement.type: self.stable_placement_constraints,
+            NearPlacement.type: self.near_placement_constraints,
             ValidPush.type: self.valid_push_constraints,
             ValidPushStick.type: self.valid_push_stick_constraints,
             TrajectoryLength.type: self.traj_length_costs,
@@ -140,6 +143,23 @@ class CostFunction:
             target_z = surface_z + world.collision_activation_distance + 2e-3  # add some buffer
             self.surface_to_target_z[surface] = target_z
 
+        # Pre-compute reference xy positions and per-constraint distance thresholds for NearPlacement.
+        # Threshold = ref_half_extent + obj_half_extent + 3cm gap, derived from initial-pose AABBs.
+        self.near_ref_xy = {}  # reference name -> (2,) tensor
+        self.near_thresholds = []  # per-constraint scalar threshold (matches order of near_placement_constraints)
+        device = self.world.device
+        for con in self.near_placement_constraints:
+            obj_name, _, ref_name = con.params
+            if ref_name not in self.near_ref_xy:
+                ref_aabb = self.world.get_aabb(ref_name)
+                self.near_ref_xy[ref_name] = (ref_aabb[0, :2] + ref_aabb[1, :2]) / 2
+            ref_half = ((self.world.get_aabb(ref_name)[1, :2] - self.world.get_aabb(ref_name)[0, :2]).max() / 2).item()
+            obj_aabb = self.world.get_aabb(obj_name)
+            obj_half = ((obj_aabb[1, :2] - obj_aabb[0, :2]).max() / 2).item()
+            self.near_thresholds.append(
+                torch.tensor(ref_half + obj_half + 0.03, dtype=torch.float32, device=device)
+            )
+
         # Store the button AABBs for ValidPush
         self.button_to_action = {}
         self.button_aabbs = []
@@ -201,7 +221,7 @@ class CostFunction:
             if op_name == "Pick":
                 obj = ground_op.values[0]
                 self.activated_obj.add(obj)
-            elif op_name == "Place":
+            elif op_name == "Place" or op_name == "PlaceNear":
                 obj = ground_op.values[0]
                 pose = ground_op.values[2]
                 self.activated_obj.add(obj)
@@ -442,6 +462,29 @@ class CostFunction:
         }
         return stable_placement_cost
 
+    def near_placement_costs(self, rollout: Rollout) -> Union[dict, None]:
+        """One-sided lateral-distance cost: penalize placement xy farther than threshold from the reference's xy."""
+        if not self.near_placement_constraints:
+            return None
+
+        near_vals = {}
+        for con, threshold in zip(self.near_placement_constraints, self.near_thresholds):
+            obj_name, placement, ref_name = con.params
+            pose_ts = rollout["action_to_pose_ts"][placement]
+            obj_pose = rollout["obj_to_pose"][obj_name][:, pose_ts]  # (b, 4, 4)
+            obj_xy = obj_pose[:, :2, 3]  # (b, 2)
+            ref_xy = self.near_ref_xy[ref_name]
+            dist_xy = torch.linalg.norm(obj_xy - ref_xy[None], dim=-1)  # (b,)
+            # Shape (b, 1) to match the 2-D convention used by other constraints
+            # (e.g. StablePlacement). heuristic_fn in algorithm.py only handles 2-D values correctly.
+            near_vals[f"{obj_name}_near_{ref_name}"] = torch.relu(dist_xy - threshold).unsqueeze(-1)
+
+        return {
+            "type": "constraint",
+            "constraints": self.near_placement_constraints,
+            "values": near_vals,
+        }
+
     def trajectory_costs(self, rollout: Rollout) -> dict:
         """Trajectory costs, just joint space distance between configurations for now."""
         traj_cost = {
@@ -609,6 +652,11 @@ class CostFunction:
         with torch.profiler.record_function("cost::stable_placement"):
             stable_placement_cost = self.stable_placement_costs(rollout, obj_to_spheres)
         add_cost(StablePlacement.type, stable_placement_cost)
+
+        # Near placement cost
+        with torch.profiler.record_function("cost::near_placement"):
+            near_placement_cost = self.near_placement_costs(rollout)
+        add_cost(NearPlacement.type, near_placement_cost)
 
         # Valid motions don't exceed joint limits
         with torch.profiler.record_function("cost::motion"):

--- a/cutamp/cost_reduction.py
+++ b/cutamp/cost_reduction.py
@@ -26,7 +26,11 @@ class CostReducer:
         }
 
     def _get_multiplier(self, cost_type: str, name: str) -> Optional[float]:
-        return self.cost_to_multiplier.get((cost_type, name))
+        # Fall back to a per-type "default" multiplier when there's no exact (type, name) match.
+        key = (cost_type, name)
+        if key in self.cost_to_multiplier:
+            return self.cost_to_multiplier[key]
+        return self.cost_to_multiplier.get((cost_type, "default"))
 
     def get_cost(self, cost_dict: Dict[str, dict], consider_types: Set[str]) -> Float[torch.Tensor, "num_particles"]:
         """Returns total cost per particle by taking weighted sum of considered cost types."""

--- a/cutamp/envs/assets/place_near.yml
+++ b/cutamp/envs/assets/place_near.yml
@@ -1,0 +1,30 @@
+name: place_near
+geometries:
+  cuboid:
+    # Movables
+    block_a:
+      color: [244, 67, 54]
+      dims: [0.05, 0.05, 0.05]
+      pose: [0.55, -0.3, 0.04, -0.97, 0.0, 0.0, 0.23]
+    block_b:
+      color: [33, 150, 243]
+      dims: [0.05, 0.05, 0.05]
+      pose: [0.5, 0.05, 0.04, 1.0, 0.0, 0.0, 0.0]
+
+    # Statics
+    floor:
+      color: [235, 196, 145]
+      dims: [1.3, 0.85, 0.04]
+      pose: [0.25, 0.0, -0.02, 1.0, 0.0, 0.0, 0.0]
+    goal:
+      color: [186, 255, 201]
+      dims: [0.35, 0.35, 0.01]
+      pose: [0.5, 0.05, 0.005, 1.0, 0.0, 0.0, 0.0]
+
+types:
+  Movable: [block_a, block_b]
+  Surface: [floor, goal]
+
+goal:
+  - Near: [block_a, block_b]
+  - HandEmpty: []

--- a/cutamp/motion_solver.py
+++ b/cutamp/motion_solver.py
@@ -22,7 +22,7 @@ from curobo.types.state import JointState
 from curobo.wrap.reacher.motion_gen import MotionGenPlanConfig, MotionGen
 from cutamp.config import TAMPConfiguration
 from cutamp.optimize_plan import PlanContainer
-from cutamp.tamp_domain import MoveHolding, Push, PushStick, MoveFree, Place, Pick
+from cutamp.tamp_domain import MoveHolding, Push, PushStick, MoveFree, Place, PlaceNear, Pick
 from cutamp.tamp_world import TAMPWorld
 from cutamp.utils.common import Particles, action_6dof_to_mat4x4, action_4dof_to_mat4x4
 from cutamp.utils.timer import TorchTimer
@@ -250,9 +250,12 @@ def solve_curobo(
             all_pos = torch.cat([all_pos, interp], dim=1)
             ts = visualizer.log_joint_trajectory(all_pos, timeline=timeline, start_time=ts, dt=dt)
 
-        # Place
-        elif op_name == Place.name:
-            obj, grasp, placement, surface, q = ground_op.values
+        # Place / PlaceNear (motion plan is identical; reference is cost-only)
+        elif op_name == Place.name or op_name == PlaceNear.name:
+            if op_name == Place.name:
+                obj, grasp, placement, surface, q = ground_op.values
+            else:
+                obj, grasp, placement, surface, _reference, q = ground_op.values
             assert last_js is not None
 
             with timer.time(f"{timeline}_planning"):

--- a/cutamp/motion_solver.py
+++ b/cutamp/motion_solver.py
@@ -250,12 +250,10 @@ def solve_curobo(
             all_pos = torch.cat([all_pos, interp], dim=1)
             ts = visualizer.log_joint_trajectory(all_pos, timeline=timeline, start_time=ts, dt=dt)
 
-        # Place / PlaceNear (motion plan is identical; reference is cost-only)
+        # Place / PlaceNear — identical motion plan; PlaceNear's reference is cost-only
         elif op_name == Place.name or op_name == PlaceNear.name:
-            if op_name == Place.name:
-                obj, grasp, placement, surface, q = ground_op.values
-            else:
-                obj, grasp, placement, surface, _reference, q = ground_op.values
+            obj, grasp, placement, surface = ground_op.values[:4]
+            q = ground_op.values[-1]
             assert last_js is not None
 
             with timer.time(f"{timeline}_planning"):

--- a/cutamp/motion_solver.py
+++ b/cutamp/motion_solver.py
@@ -252,8 +252,10 @@ def solve_curobo(
 
         # Place / PlaceNear — identical motion plan; PlaceNear's reference is cost-only
         elif op_name == Place.name or op_name == PlaceNear.name:
-            param_values = ground_op.param_values
-            obj, grasp, placement, surface, q = (param_values[k] for k in ("obj", "grasp", "placement", "surface", "q"))
+            if op_name == Place.name:
+                obj, grasp, placement, surface, q = ground_op.values
+            else:
+                obj, grasp, placement, surface, _, q = ground_op.values
             assert last_js is not None
 
             with timer.time(f"{timeline}_planning"):

--- a/cutamp/motion_solver.py
+++ b/cutamp/motion_solver.py
@@ -252,8 +252,8 @@ def solve_curobo(
 
         # Place / PlaceNear — identical motion plan; PlaceNear's reference is cost-only
         elif op_name == Place.name or op_name == PlaceNear.name:
-            obj, grasp, placement, surface = ground_op.values[:4]
-            q = ground_op.values[-1]
+            param_values = ground_op.param_values
+            obj, grasp, placement, surface, q = (param_values[k] for k in ("obj", "grasp", "placement", "surface", "q"))
             assert last_js is not None
 
             with timer.time(f"{timeline}_planning"):

--- a/cutamp/particle_initialization.py
+++ b/cutamp/particle_initialization.py
@@ -23,7 +23,7 @@ from cutamp.samplers import (
     place_4dof_sampler,
     sample_yaw,
 )
-from cutamp.tamp_domain import MoveFree, MoveHolding, Pick, Place, Push, PushStick
+from cutamp.tamp_domain import MoveFree, MoveHolding, Pick, Place, PlaceNear, Push, PushStick
 from cutamp.tamp_world import TAMPWorld
 from cutamp.task_planning import PlanSkeleton
 from cutamp.utils.common import (
@@ -219,9 +219,13 @@ class ParticleInitializer:
                         "confidences": particles[f"{grasp}_confidences"],
                     }
 
-            # Place
-            elif op_name == Place.name:
-                obj, grasp, placement, surface, q = params
+            # Place / PlaceNear (placement sampling is identical; PlaceNear's lateral pull
+            # toward the reference is handled in the cost function, not at init time)
+            elif op_name == Place.name or op_name == PlaceNear.name:
+                if op_name == Place.name:
+                    obj, grasp, placement, surface, q = params
+                else:
+                    obj, grasp, placement, surface, _reference, q = params
                 if not world.has_object(obj):
                     raise ValueError(f"{obj=} not found in world")
                 if grasp not in particles:

--- a/cutamp/particle_initialization.py
+++ b/cutamp/particle_initialization.py
@@ -221,10 +221,10 @@ class ParticleInitializer:
 
             # Place / PlaceNear — identical sampling; PlaceNear's reference is handled in the cost function
             elif op_name == Place.name or op_name == PlaceNear.name:
-                param_values = ground_op.param_values
-                obj, grasp, placement, surface, q = (
-                    param_values[k] for k in ("obj", "grasp", "placement", "surface", "q")
-                )
+                if op_name == Place.name:
+                    obj, grasp, placement, surface, q = ground_op.values
+                else:
+                    obj, grasp, placement, surface, _, q = ground_op.values
                 if not world.has_object(obj):
                     raise ValueError(f"{obj=} not found in world")
                 if grasp not in particles:

--- a/cutamp/particle_initialization.py
+++ b/cutamp/particle_initialization.py
@@ -219,13 +219,10 @@ class ParticleInitializer:
                         "confidences": particles[f"{grasp}_confidences"],
                     }
 
-            # Place / PlaceNear (placement sampling is identical; PlaceNear's lateral pull
-            # toward the reference is handled in the cost function, not at init time)
+            # Place / PlaceNear — identical sampling; PlaceNear's reference is handled in the cost function
             elif op_name == Place.name or op_name == PlaceNear.name:
-                if op_name == Place.name:
-                    obj, grasp, placement, surface, q = params
-                else:
-                    obj, grasp, placement, surface, _reference, q = params
+                obj, grasp, placement, surface = params[:4]
+                q = params[-1]
                 if not world.has_object(obj):
                     raise ValueError(f"{obj=} not found in world")
                 if grasp not in particles:

--- a/cutamp/particle_initialization.py
+++ b/cutamp/particle_initialization.py
@@ -221,8 +221,10 @@ class ParticleInitializer:
 
             # Place / PlaceNear — identical sampling; PlaceNear's reference is handled in the cost function
             elif op_name == Place.name or op_name == PlaceNear.name:
-                obj, grasp, placement, surface = params[:4]
-                q = params[-1]
+                param_values = ground_op.param_values
+                obj, grasp, placement, surface, q = (
+                    param_values[k] for k in ("obj", "grasp", "placement", "surface", "q")
+                )
                 if not world.has_object(obj):
                     raise ValueError(f"{obj=} not found in world")
                 if grasp not in particles:

--- a/cutamp/rollout.py
+++ b/cutamp/rollout.py
@@ -164,12 +164,9 @@ class RolloutFunction:
                 action_to_ts[grasp_name] = ts
                 action_to_pose_ts[grasp_name] = pose_ts
 
-            # Place / PlaceNear (rollout only needs obj/grasp/placement; reference is cost-only)
+            # Place / PlaceNear — rollout only needs obj/grasp/placement; PlaceNear's reference is cost-only
             elif op_name == Place.name or op_name == PlaceNear.name:
-                if op_name == Place.name:
-                    obj_name, grasp_name, place_name, _, _ = ground_op.values
-                else:
-                    obj_name, grasp_name, place_name, _, _, _ = ground_op.values
+                obj_name, grasp_name, place_name = ground_op.values[:3]
 
                 # Place is desired object pose in world frame
                 place_4dof = particles[place_name]

--- a/cutamp/rollout.py
+++ b/cutamp/rollout.py
@@ -14,7 +14,7 @@ from jaxtyping import Float
 
 from cutamp.utils.common import Particles, action_6dof_to_mat4x4, action_4dof_to_mat4x4
 from cutamp.config import TAMPConfiguration
-from cutamp.tamp_domain import MoveFree, MoveHolding, Pick, Place, Push, PushStick, Conf
+from cutamp.tamp_domain import MoveFree, MoveHolding, Pick, Place, PlaceNear, Push, PushStick, Conf
 from cutamp.tamp_world import (
     TAMPWorld,
 )
@@ -164,9 +164,12 @@ class RolloutFunction:
                 action_to_ts[grasp_name] = ts
                 action_to_pose_ts[grasp_name] = pose_ts
 
-            # Place
-            elif op_name == Place.name:
-                obj_name, grasp_name, place_name, _, _ = ground_op.values
+            # Place / PlaceNear (rollout only needs obj/grasp/placement; reference is cost-only)
+            elif op_name == Place.name or op_name == PlaceNear.name:
+                if op_name == Place.name:
+                    obj_name, grasp_name, place_name, _, _ = ground_op.values
+                else:
+                    obj_name, grasp_name, place_name, _, _, _ = ground_op.values
 
                 # Place is desired object pose in world frame
                 place_4dof = particles[place_name]

--- a/cutamp/scripts/run_cutamp.py
+++ b/cutamp/scripts/run_cutamp.py
@@ -59,6 +59,9 @@ def load_demo_env(name: str) -> TAMPEnvironment:
     elif name == "pick_block":
         env_path = os.path.join(get_env_dir(), "pick_block.yml")
         env = load_env(env_path)
+    elif name == "place_near":
+        env_path = os.path.join(get_env_dir(), "place_near.yml")
+        env = load_env(env_path)
     else:
         raise ValueError(f"Unknown environment name: {name}")
     return env
@@ -108,6 +111,7 @@ def entrypoint():
             "unpack",
             "blocks_5",
             "pick_block",
+            "place_near",
         ],
     )
     parser.add_argument(
@@ -205,6 +209,11 @@ def entrypoint():
     # Object collision spheres and placement
     parser.add_argument("--coll_n_spheres", type=int, default=50, help="Number of collision spheres per object.")
     parser.add_argument(
+        "--near_placement",
+        action="store_true",
+        help="Enable the experimental PlaceNear operator. Required for envs with Near goals (e.g. place_near).",
+    )
+    parser.add_argument(
         "--placement_shrink_dist",
         type=float,
         default=0.0,
@@ -269,6 +278,7 @@ def entrypoint():
         viz_robot_mesh=not args.disable_robot_mesh,
         experiment_root=args.experiment_root,
         coll_n_spheres=args.coll_n_spheres,
+        near_placement=args.near_placement,
         # Note: these are new features with this fork of cuTAMP
         placement_check="obb",
         placement_shrink_dist=args.placement_shrink_dist,

--- a/cutamp/scripts/utils.py
+++ b/cutamp/scripts/utils.py
@@ -26,7 +26,7 @@ _log = logging.getLogger(__name__)
 default_constraint_to_mult = {
     KinematicConstraint.type: {"pos_err": 1.0, "rot_err": 5.0},
     StablePlacement.type: {"goal_support": 2.0},
-    NearPlacement.type: {"default": 1.0},
+    NearPlacement.type: {"default": 0.2},
     TrajectoryLength.type: {"traj_length": 1e-3},
     "soft": {
         "dist_from_origin": 5e-1,
@@ -89,7 +89,7 @@ default_constraint_to_tol = {
         "stove_support": 1e-2,
     },
     ValidPush.type: {"dist_from_button": 0.0},
-    NearPlacement.type: {"default": 1e-2},
+    NearPlacement.type: {"default": 5e-2},
 }
 
 

--- a/cutamp/scripts/utils.py
+++ b/cutamp/scripts/utils.py
@@ -10,7 +10,14 @@
 import logging
 import sys
 
-from cutamp.task_planning.constraints import KinematicConstraint, StablePlacement, Collision, Motion, ValidPush
+from cutamp.task_planning.constraints import (
+    Collision,
+    KinematicConstraint,
+    Motion,
+    NearPlacement,
+    StablePlacement,
+    ValidPush,
+)
 from cutamp.task_planning.costs import TrajectoryLength
 
 
@@ -19,6 +26,7 @@ _log = logging.getLogger(__name__)
 default_constraint_to_mult = {
     KinematicConstraint.type: {"pos_err": 1.0, "rot_err": 5.0},
     StablePlacement.type: {"goal_support": 2.0},
+    NearPlacement.type: {"default": 1.0},
     TrajectoryLength.type: {"traj_length": 1e-3},
     "soft": {
         "dist_from_origin": 5e-1,
@@ -81,6 +89,7 @@ default_constraint_to_tol = {
         "stove_support": 1e-2,
     },
     ValidPush.type: {"dist_from_button": 0.0},
+    NearPlacement.type: {"default": 1e-2},
 }
 
 

--- a/cutamp/scripts/utils.py
+++ b/cutamp/scripts/utils.py
@@ -26,6 +26,7 @@ _log = logging.getLogger(__name__)
 default_constraint_to_mult = {
     KinematicConstraint.type: {"pos_err": 1.0, "rot_err": 5.0},
     StablePlacement.type: {"goal_support": 2.0},
+    # Weight on the distance penalty. Should tune for your use case.
     NearPlacement.type: {"default": 0.2},
     TrajectoryLength.type: {"traj_length": 1e-3},
     "soft": {
@@ -89,6 +90,7 @@ default_constraint_to_tol = {
         "stove_support": 1e-2,
     },
     ValidPush.type: {"dist_from_button": 0.0},
+    # Satisfaction slack (meters) the placement may exceed the near-placement threshold by. Should tune for your use case.
     NearPlacement.type: {"default": 5e-2},
 }
 

--- a/cutamp/scripts/utils.py
+++ b/cutamp/scripts/utils.py
@@ -90,7 +90,8 @@ default_constraint_to_tol = {
         "stove_support": 1e-2,
     },
     ValidPush.type: {"dist_from_button": 0.0},
-    # Satisfaction slack (meters) the placement may exceed the near-placement threshold by. Should tune for your use case.
+    # Satisfaction slack (meters) on the L2 (center-to-center xy) distance the placement may exceed the
+    # near-placement threshold by. Should tune for your use case.
     NearPlacement.type: {"default": 5e-2},
 }
 

--- a/cutamp/tamp_domain.py
+++ b/cutamp/tamp_domain.py
@@ -21,6 +21,7 @@ from cutamp.task_planning.constraints import (
     CollisionFreePlacement,
     KinematicConstraint,
     Motion,
+    NearPlacement,
     StablePlacement,
     ValidPush,
     ValidPushStick,
@@ -53,6 +54,7 @@ IsSurface = Fluent("IsSurface", [Parameter("surface", Surface)])
 IsStick = Fluent("IsStick", [Parameter("obj", Movable)])
 HasNotPickedUp = Fluent("HasNotPickedUp", [Parameter("obj", Movable)])
 On = Fluent("On", [Parameter("obj", Movable), Parameter("surface", Surface)])
+Near = Fluent("Near", [Parameter("obj", Movable), Parameter("reference", Movable)])
 
 all_tamp_fluents = [
     At,
@@ -70,6 +72,7 @@ all_tamp_fluents = [
     IsStick,
     HasNotPickedUp,
     On,
+    Near,
 ]
 
 
@@ -82,6 +85,7 @@ traj = Parameter("traj", Traj)
 obj = Parameter("obj", Movable)
 button = Parameter("button", Button)
 surface = Parameter("surface", Surface)
+reference = Parameter("reference", Movable)
 
 grasp = Parameter("grasp", Grasp)
 pose = Parameter("pose", Pose)
@@ -161,6 +165,33 @@ Place = TAMPOperator(
 )
 
 
+PlaceNear = TAMPOperator(
+    "PlaceNear",
+    [obj, grasp, placement, surface, reference, q],
+    preconditions=[
+        At(q),
+        Holding(obj),
+        HoldingWithGrasp(obj, grasp),
+        IsSurface(surface),
+        IsMovable(reference),
+        JustMoved(),
+    ],
+    add_effects=[HandEmpty(), CanMove(), On(obj, surface), Near(obj, reference)],
+    del_effects=[
+        Holding(obj),
+        HoldingWithGrasp(obj, grasp),
+        JustMoved(),
+    ],
+    constraints=[
+        KinematicConstraint(q, placement),
+        StablePlacement(obj, grasp, placement, surface),
+        CollisionFreePlacement(obj, placement, surface),
+        NearPlacement(obj, placement, reference),
+    ],
+    costs=[],
+)
+
+
 Push = TAMPOperator(
     "Push",
     [button, pose, q],
@@ -197,7 +228,7 @@ PushStick = TAMPOperator(
     costs=[],
 )
 
-all_tamp_operators = [MoveFree, MoveHolding, Pick, Place, Push, PushStick]
+all_tamp_operators = [MoveFree, MoveHolding, Pick, Place, PlaceNear, Push, PushStick]
 
 
 def get_initial_state(

--- a/cutamp/task_planning/base_structs.py
+++ b/cutamp/task_planning/base_structs.py
@@ -165,11 +165,6 @@ class GroundOperator:
     add_effects: set[Atom]
     del_effects: set[Atom]
 
-    @property
-    def param_values(self) -> dict[str, str]:
-        """Map parameter name to ground value."""
-        return {param.name: value for param, value in zip(self.operator.parameters, self.values)}
-
     def apply(self, state: State) -> State:
         """Apply this ground operator to a state."""
         # Make sure preconditions are satisfied

--- a/cutamp/task_planning/base_structs.py
+++ b/cutamp/task_planning/base_structs.py
@@ -165,6 +165,11 @@ class GroundOperator:
     add_effects: set[Atom]
     del_effects: set[Atom]
 
+    @property
+    def param_values(self) -> dict[str, str]:
+        """Map parameter name to ground value."""
+        return {param.name: value for param, value in zip(self.operator.parameters, self.values)}
+
     def apply(self, state: State) -> State:
         """Apply this ground operator to a state."""
         # Make sure preconditions are satisfied

--- a/cutamp/task_planning/constraints.py
+++ b/cutamp/task_planning/constraints.py
@@ -52,6 +52,11 @@ class StablePlacement(Constraint):
         super().__init__(obj, grasp, placement, surface)
 
 
+class NearPlacement(Constraint):
+    def __init__(self, obj, placement, reference):
+        super().__init__(obj, placement, reference)
+
+
 class ValidPush(Constraint):
     def __init__(self, button, push_pose):
         super().__init__(button, push_pose)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@
 
 [project]
 name = "cuTAMP"
-version = "0.0.5"
+version = "0.0.6"
 description = "cuTAMP"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_near_placement.py
+++ b/tests/test_near_placement.py
@@ -1,0 +1,93 @@
+"""Tests for the PlaceNear operator and the config.near_placement gating.
+
+Run with: pytest tests/test_near_placement.py -v
+"""
+
+import os
+
+import pytest
+import torch
+
+from cutamp.tamp_domain import HandEmpty, Near, On, PlaceNear, all_tamp_operators, get_initial_state
+from cutamp.task_planning.search import breadth_first_search
+
+gpu = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires GPU")
+
+
+def test_near_goal_reachable_with_place_near():
+    """With the full operator set, a Near goal is solved by a plan that uses PlaceNear."""
+    initial = get_initial_state(movables=["a", "b"], surfaces=["table"])
+    goal = frozenset({Near.ground("a", "b"), HandEmpty.ground()})
+
+    plan = next(breadth_first_search(initial, goal, all_tamp_operators))
+    assert any(op.operator is PlaceNear for op in plan), f"expected a PlaceNear in the plan, got {plan}"
+
+
+def test_only_place_near_achieves_near():
+    """PlaceNear is the only operator that adds a Near atom.
+    If a Near effect were ever added elsewhere, the gating would silently break.
+    """
+    achievers = [op for op in all_tamp_operators if any(eff.name == Near.name for eff in op.add_effects)]
+    assert achievers == [PlaceNear]
+
+
+def test_gated_operators_still_solve_plain_placement():
+    """Dropping PlaceNear (near_placement=False) must not regress ordinary On-goal planning."""
+    initial = get_initial_state(movables=["a"], surfaces=["table"])
+    goal = frozenset({On.ground("a", "table"), HandEmpty.ground()})
+    gated = [op for op in all_tamp_operators if op is not PlaceNear]
+
+    plan = next(breadth_first_search(initial, goal, gated))
+    assert any(op.operator.name == "Place" for op in plan), f"expected a Place in the plan, got {plan}"
+
+
+def _make_config(near_placement: bool) -> "TAMPConfiguration":
+    from cutamp.config import TAMPConfiguration
+
+    return TAMPConfiguration(
+        num_particles=512,
+        robot="fr3_robotiq",
+        num_opt_steps=500,
+        max_loop_dur=20.0,
+        enable_visualizer=False,
+        rr_spawn=False,
+        enable_experiment_logging=False,
+        near_placement=near_placement,
+    )
+
+
+@gpu
+def test_near_goal_without_flag_raises():
+    """A Near goal with near_placement=False must fail fast rather than search forever."""
+    from cutamp.algorithm import run_cutamp
+    from cutamp.constraint_checker import ConstraintChecker
+    from cutamp.cost_reduction import CostReducer
+    from cutamp.envs.utils import get_env_dir, load_env
+    from cutamp.scripts.utils import default_constraint_to_mult, default_constraint_to_tol
+
+    env = load_env(os.path.join(get_env_dir(), "place_near.yml"))
+    config = _make_config(near_placement=False)
+    cost_reducer = CostReducer(default_constraint_to_mult.copy())
+    constraint_checker = ConstraintChecker(default_constraint_to_tol.copy())
+
+    with pytest.raises(ValueError, match=r"Near atom"):
+        run_cutamp(env, config, cost_reducer, constraint_checker)
+
+
+@gpu
+def test_place_near_finds_satisfying_plan():
+    """With near_placement=True, planning the Near goal yields satisfying particles."""
+    from cutamp.algorithm import run_cutamp
+    from cutamp.constraint_checker import ConstraintChecker
+    from cutamp.cost_reduction import CostReducer
+    from cutamp.envs.utils import get_env_dir, load_env
+    from cutamp.scripts.utils import default_constraint_to_mult, default_constraint_to_tol
+
+    env = load_env(os.path.join(get_env_dir(), "place_near.yml"))
+    config = _make_config(near_placement=True)
+    cost_reducer = CostReducer(default_constraint_to_mult.copy())
+    constraint_checker = ConstraintChecker(default_constraint_to_tol.copy())
+
+    _, num_satisfying, failure_reason = run_cutamp(env, config, cost_reducer, constraint_checker)
+    assert failure_reason is None
+    assert num_satisfying > 0


### PR DESCRIPTION
## Support pick-and-place "next to"

Adds the ability to plan placements that put an object **next to** a reference object, e.g. "place the cup next to the plate." Introduces a new fluent, operator, constraint, and cost, gated behind an off-by-default config flag so existing planning behavior is unchanged.

### What's new

**Domain** (`tamp_domain.py`)
- `Near(obj, reference)` fluent — "obj is placed near reference."
- `PlaceNear` operator — a superset of `Place` with params `[obj, grasp, placement, surface, reference, q]`. Its add-effects are `Place`'s effects plus `Near(obj, reference)`, and it carries the extra `NearPlacement` constraint. Added to `all_tamp_operators`.

**Constraint + cost** (`task_planning/constraints.py`, `cost_function.py`)
- `NearPlacement(obj, placement, reference)` constraint.
- Cost is a one-sided hinge on lateral distance: `relu(dist_xy − threshold)`, where `threshold = reference_half_extent + obj_half_extent + 3 cm gap` (computed per-constraint from object AABBs). Zero cost once the object is within the threshold, growing only when it's too far.

**Config flag** (`config.py`, `algorithm.py`)
- New `near_placement: bool = False` on `TAMPConfiguration`.
- When `False` (default), `PlaceNear` is dropped from the operator set, so search is **identical to pre-PR behavior**. This matters because `PlaceNear`'s superset effects would otherwise let forward search explore `PlaceNear` skeletons for plain `On` goals, diluting the initial-plan budget.
- A `Near` goal with `near_placement=False` raises a clear `ValueError` (fail fast rather than search forever).

### Demo
```bash
pixi run cutamp-demo --env place_near --near_placement
```
New `place_near.yml` env (`block_a` placed next to reference `block_b`) plus CLI wiring: `--near_placement` flag and the `place_near` env registered in `run_cutamp.py`.

### Tests
`tests/test_near_placement.py`:
- CPU: a `Near` goal is solved by a `PlaceNear` plan; `PlaceNear` is the only `Near`-achiever (the invariant the gating relies on); dropping `PlaceNear` still solves ordinary `On` goals.
- GPU: `near_placement=False` + `Near` goal raises; `near_placement=True` finds satisfying particles on `place_near` (which requires the `NearPlacement` constraint to hold).

### Tuning
`NearPlacement` defaults in `scripts/utils.py` — cost weight `0.2`, satisfaction slack `5e-2 m`. Both are scene-dependent and meant to be tuned per use case.