### PR TITLE
Fix leaked state across multi-plan run_cutamp invocations

### DIFF
--- a/cutamp/experiment_logger.py
+++ b/cutamp/experiment_logger.py
@@ -27,17 +27,18 @@ _GIT_CWD = Path(__file__).parent
 def _collect_git_info() -> dict:
     """Return git commit hash, dirty status, and porcelain status for metadata."""
     try:
+        # Pin encoding so non-ASCII bytes (e.g. unicode in filenames) don't trip the locale's default.
         commit = subprocess.check_output(
             ["git", "rev-parse", "HEAD"],
             cwd=_GIT_CWD,
             stderr=subprocess.DEVNULL,
-            text=True,
+            encoding="utf-8",
         ).strip()
         porcelain = subprocess.check_output(
             ["git", "status", "--porcelain"],
             cwd=_GIT_CWD,
             stderr=subprocess.DEVNULL,
-            text=True,
+            encoding="utf-8",
         )
         dirty = bool(porcelain.strip())
         return {"commit": commit, "dirty": dirty, "porcelain": porcelain.strip() if dirty else None}
@@ -53,7 +54,7 @@ def _get_git_diff() -> str | None:
             ["git", "diff", "HEAD"],
             cwd=_GIT_CWD,
             stderr=subprocess.DEVNULL,
-            text=True,
+            encoding="utf-8",
         )
         return diff if diff else None
     except (FileNotFoundError, subprocess.CalledProcessError):

--- a/cutamp/optimize_plan.py
+++ b/cutamp/optimize_plan.py
@@ -143,77 +143,80 @@ class ParticleOptimizer:
                 _log.warning(f"Optimization exceeded max time of {self.config.max_loop_dur:.2f}s")
                 time_exceeded = True
                 break
+            # try/finally so the timer is released even when the body breaks/raises mid-iteration.
             timer.start("optimization_step")
-            optimizer.zero_grad()
+            try:
+                optimizer.zero_grad()
 
-            with torch.profiler.record_function("rollout"):
-                rollout = rollout_fn(particles)
-            with torch.profiler.record_function("cost_fn"):
-                cost_dict = cost_fn(rollout)
-            with torch.profiler.record_function("cost_reduction"):
-                costs = self.cost_reducer(cost_dict, consider_types=consider_types)
-            with torch.profiler.record_function("satisfying_mask"):
-                satisfying_mask = self.get_satisfying_mask(cost_dict, verbose=False)
-            num_satisfying = satisfying_mask.sum().item()
-            # If num satisfying bigger than desired proportion, break
-            if self.num_satisfying_break is not None and num_satisfying >= self.num_satisfying_break:
-                _log.info(
-                    f"Found {num_satisfying} >= {self.num_satisfying_break} ({self.config.prop_satisfying_break * 100:.2f}%) satisfying particles "
-                )
-                break
+                with torch.profiler.record_function("rollout"):
+                    rollout = rollout_fn(particles)
+                with torch.profiler.record_function("cost_fn"):
+                    cost_dict = cost_fn(rollout)
+                with torch.profiler.record_function("cost_reduction"):
+                    costs = self.cost_reducer(cost_dict, consider_types=consider_types)
+                with torch.profiler.record_function("satisfying_mask"):
+                    satisfying_mask = self.get_satisfying_mask(cost_dict, verbose=False)
+                num_satisfying = satisfying_mask.sum().item()
+                # If num satisfying bigger than desired proportion, break
+                if self.num_satisfying_break is not None and num_satisfying >= self.num_satisfying_break:
+                    _log.info(
+                        f"Found {num_satisfying} >= {self.num_satisfying_break} ({self.config.prop_satisfying_break * 100:.2f}%) satisfying particles "
+                    )
+                    break
 
-            opt_metrics["num_satisfying"].append(num_satisfying)
+                opt_metrics["num_satisfying"].append(num_satisfying)
 
-            if num_satisfying > 0 and not found_solution:
-                if timer.has_timer("first_solution"):
-                    time_to_first_sol = timer.stop("first_solution")
-                    _log.info(f"Found first solution in {time_to_first_sol:.2f}s after sampling plans")
+                if num_satisfying > 0 and not found_solution:
+                    if timer.has_timer("first_solution"):
+                        time_to_first_sol = timer.stop("first_solution")
+                        _log.info(f"Found first solution in {time_to_first_sol:.2f}s after sampling plans")
 
-                torch.cuda.synchronize()
-                opt_metrics["opt_start_to_first_sol"] = time.perf_counter() - start_time
-                found_solution = True
+                    torch.cuda.synchronize()
+                    opt_metrics["opt_start_to_first_sol"] = time.perf_counter() - start_time
+                    found_solution = True
 
-            loss = costs.mean()
-            opt_metrics["loss"].append(loss.item())
+                loss = costs.mean()
+                opt_metrics["loss"].append(loss.item())
 
-            # Compute soft costs if required (even if we don't optimize them)
-            if self.config.soft_cost is not None:
-                soft_costs = self.cost_reducer.soft_costs(cost_dict)
-                best_soft_cost = soft_costs[satisfying_mask].min().item() if num_satisfying > 0 else None
-                opt_metrics["best_soft_costs"].append(best_soft_cost)
+                # Compute soft costs if required (even if we don't optimize them)
+                if self.config.soft_cost is not None:
+                    soft_costs = self.cost_reducer.soft_costs(cost_dict)
+                    best_soft_cost = soft_costs[satisfying_mask].min().item() if num_satisfying > 0 else None
+                    opt_metrics["best_soft_costs"].append(best_soft_cost)
 
-            # Note: no cuda synchronize here — elapsed is approximate (CPU submission time).
-            # Accurate GPU timing is available via timer.stop("optimization_step") and --torch-profile.
-            opt_metrics["elapsed"].append(time.perf_counter() - start_time)
+                # Note: no cuda synchronize here — elapsed is approximate (CPU submission time).
+                # Accurate GPU timing is available via timer.stop("optimization_step") and --torch-profile.
+                opt_metrics["elapsed"].append(time.perf_counter() - start_time)
 
-            # Visualize the optimization progress. We do this before stepping the optimizer to see current state.
-            if step % vis_every == 0 or step == num_steps - 1:
-                timer.start("visualize_opt_rollout")
-                # Visualize satisfying particles if we have any. Otherwise, just show the best particle so far.
-                if num_satisfying > 0:
-                    best_satisfying_idx = costs[satisfying_mask].argmin()
-                    best_idx = indices[satisfying_mask][best_satisfying_idx]
-                else:
-                    best_idx = costs.argmin()
+                # Visualize the optimization progress. We do this before stepping the optimizer to see current state.
+                if step % vis_every == 0 or step == num_steps - 1:
+                    timer.start("visualize_opt_rollout")
+                    # Visualize satisfying particles if we have any. Otherwise, just show the best particle so far.
+                    if num_satisfying > 0:
+                        best_satisfying_idx = costs[satisfying_mask].argmin()
+                        best_idx = indices[satisfying_mask][best_satisfying_idx]
+                    else:
+                        best_idx = costs.argmin()
 
-                # Show last state after rolling out the best particle
-                visualizer.set_time_sequence(f"opt_{self.opt_counter}", step)
-                q_last = rollout["confs"][best_idx, -1].tolist()
-                visualizer.set_joint_positions(q_last)
-                for obj in rollout["obj_to_pose"]:
-                    mat4x4_last = rollout["obj_to_pose"][obj][best_idx, -1]
-                    visualizer.log_mat4x4(f"world/{obj}", mat4x4_last)
+                    # Show last state after rolling out the best particle
+                    visualizer.set_time_sequence(f"opt_{self.opt_counter}", step)
+                    q_last = rollout["confs"][best_idx, -1].tolist()
+                    visualizer.set_joint_positions(q_last)
+                    for obj in rollout["obj_to_pose"]:
+                        mat4x4_last = rollout["obj_to_pose"][obj][best_idx, -1]
+                        visualizer.log_mat4x4(f"world/{obj}", mat4x4_last)
 
-                visualizer.log_cost_dict(cost_dict)
-                visualizer.log_scalar("loss", loss.item())
-                timer.stop("visualize_opt_rollout")
+                    visualizer.log_cost_dict(cost_dict)
+                    visualizer.log_scalar("loss", loss.item())
+                    timer.stop("visualize_opt_rollout")
 
-            # Compute gradients and step the optimizer
-            with torch.profiler.record_function("backward"):
-                loss.backward()
-            with torch.profiler.record_function("optimizer_step"):
-                optimizer.step()
-            timer.stop("optimization_step")
+                # Compute gradients and step the optimizer
+                with torch.profiler.record_function("backward"):
+                    loss.backward()
+                with torch.profiler.record_function("optimizer_step"):
+                    optimizer.step()
+            finally:
+                timer.stop("optimization_step")
             pbar.set_description(
                 f"Loss: {loss:.3f}, Min: {costs.min():.3f}, {num_satisfying}/{self.config.num_particles} satisfying"
             )

--- a/cutamp/utils/common.py
+++ b/cutamp/utils/common.py
@@ -160,7 +160,8 @@ def get_world_cfg(env: TAMPEnvironment, include_movables: bool = False) -> World
     from cutamp.utils.obb import get_object_obb
 
     geoms = defaultdict(list)
-    obstacles = env.movables if include_movables else []
+    # Copy to avoid the `+=` below mutating env.movables in place.
+    obstacles = list(env.movables) if include_movables else []
     obstacles += env.statics
     for obj in obstacles:
         if isinstance(obj, Cuboid):

--- a/cutamp/utils/timer.py
+++ b/cutamp/utils/timer.py
@@ -51,10 +51,13 @@ class TorchTimer:
     @contextmanager
     def time(self, metric: str, log_callback=None):
         self.start(metric)
-        yield
-        duration = self.stop(metric)
-        if log_callback is not None:
-            log_callback(f"{metric} took {duration:.2f}s")
+        try:
+            yield
+        finally:
+            # stop() in finally so an exception inside the block doesn't leak a started timer.
+            duration = self.stop(metric)
+            if log_callback is not None:
+                log_callback(f"{metric} took {duration:.2f}s")
 
     def get_summary(self, metric: str) -> Dict[str, float]:
         """Get summary timing statistics for a given metric."""


### PR DESCRIPTION
## Summary

Four independent fixes that surface when `run_cutamp` processes multiple plans in a single invocation. Each was caught while debugging a live TiPToP run on `will/recgen`.

- **`utils/common.py` — `env.movables` mutated in place.** `get_world_cfg(include_movables=True)` aliased `obstacles = env.movables` and then did `obstacles += env.statics`, which is `list.extend(...)` — appending every static (workspace cuboids included) onto the env's movables list. After Opt N called `motion_gen.update_world(...)` on a satisfying particle, every later plan's pre-built `RolloutFunction` blew up with `KeyError('workspace_<static_name>')` because `obj_to_initial_pose` was snapshotted before the mutation. Copy with `list(...)` before extending.
- **`utils/timer.py` — `TorchTimer.time` leaked on exception.** The context manager called `start` then `yield` then `stop` with no `try/finally`. A `MotionPlanningError` raised inside the `with` block left the metric in `_start_time`, so the next `solve_curobo` call with the same `timeline` (e.g. `curobo_0`) hit `ValueError: Timer already started for curobo_0_planning`. Move `stop()` into a `finally`.
- **`optimize_plan.py` — bare `start`/`stop` leaked on break.** `ParticleOptimizer`'s per-step `timer.start("optimization_step")` and matching `stop` straddled an early `break` (the `num_satisfying_break` short-circuit). When that branch fired, the timer never stopped and the next plan's `particle_optimizer` call hit `Timer already started for optimization_step`. Wrap the body in `try/finally`.
- **`experiment_logger.py` — git subprocess decoded with locale default.** `_collect_git_info` / `_get_git_diff` passed `text=True` without `encoding=`, so under an ASCII locale a non-ASCII byte (e.g. `—`, `→`, `•` in a diff or commit message) crashed with `UnicodeDecodeError`. Pin `encoding="utf-8"` on all three calls.

The four bugs compose: fixing the `env.movables` mutation unblocked Opt 3 from running, which exposed the timer-leak-on-exception, which once fixed exposed the timer-leak-on-break, which once fixed exposed the encoding bug on a subsequent run.

## Test plan

- [ ] Re-run the TiPToP `will/recgen` scene that hit `KeyError('workspace_vention')` — verify it now progresses past Opt 2.
- [ ] Re-run a scenario where motion planning raises `MotionPlanningError` (e.g. unreachable second Pick) — verify subsequent Opt iterations don't hit `Timer already started for curobo_0_planning`.
- [ ] Force `num_satisfying_break` to trigger and confirm a second `particle_optimizer` call doesn't hit `Timer already started for optimization_step`.
- [ ] Re-run with a dirty working tree containing non-ASCII content in the diff and confirm `ExperimentLogger` initializes without raising.
- [ ] Existing `tests/` suite still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)