### PR TITLE
Update 0.0.6 release date to 2026-07-30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.0.6] - 2026-06-08
+## [0.0.6] - 2026-07-30
 
 ### Added
 - `Near(obj, reference)` fluent and `PlaceNear` operator for placing an object next to a reference object, with a `NearPlacement` constraint and a one-sided lateral-distance cost (#22)


### PR DESCRIPTION
The `[0.0.6]` section in `CHANGELOG.md` was dated `2026-06-08`, but the last change in the release (#22, "Support pick and place next to") landed on 2026-07-30. Correct the date so the changelog matches reality before we tag `v0.0.6`.

`pyproject.toml` already declares `version = "0.0.6"`, so no other changes are needed for the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)